### PR TITLE
feat: host Sanity Studio on Cloudflare with SPA routing

### DIFF
--- a/scripts/copy-studio.js
+++ b/scripts/copy-studio.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { cp, mkdir } from "node:fs/promises";
+import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -26,6 +26,15 @@ async function copyStudio() {
     // Copy studio build to dist/studio
     await cp(studioSource, studioDestination, { recursive: true });
     console.error("✓ Sanity Studio copied to dist/studio");
+
+    // Rewrite asset paths in index.html so they resolve under /studio/
+    // Sanity builds with root-relative paths (/static/...) but the studio
+    // is served from /studio/, so assets live at /studio/static/...
+    const indexPath = join(studioDestination, "index.html");
+    const html = await readFile(indexPath, "utf-8");
+    const rewritten = html.replaceAll('"/static/', '"/studio/static/');
+    await writeFile(indexPath, rewritten, "utf-8");
+    console.error("✓ Rewritten asset paths for /studio/ base path");
   } catch (error) {
     console.error("Error copying studio:", error);
     process.exit(1);

--- a/worker.ts
+++ b/worker.ts
@@ -6,7 +6,7 @@ export default {
   async fetch(request: Request, env: IEnv): Promise<Response> {
     const url = new URL(request.url);
 
-    if (url.pathname.startsWith("/studio")) {
+    if (url.pathname === "/studio" || url.pathname.startsWith("/studio/")) {
       const assetResponse = await env.ASSETS.fetch(request);
       if (assetResponse.status !== 404) {
         return assetResponse;

--- a/worker.ts
+++ b/worker.ts
@@ -11,6 +11,15 @@ export default {
       if (assetResponse.status !== 404) {
         return assetResponse;
       }
+
+      const method = request.method.toUpperCase();
+      const accept = request.headers.get("Accept") || "";
+      const isNavigationRequest =
+        (method === "GET" || method === "HEAD") && accept.includes("text/html");
+
+      if (!isNavigationRequest) {
+        return assetResponse;
+      }
       return env.ASSETS.fetch(new Request(new URL("/studio/index.html", request.url), request));
     }
 

--- a/worker.ts
+++ b/worker.ts
@@ -1,0 +1,19 @@
+interface IEnv {
+  ASSETS: { fetch(input: RequestInfo, init?: RequestInit): Promise<Response> };
+}
+
+export default {
+  async fetch(request: Request, env: IEnv): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname.startsWith("/studio")) {
+      const assetResponse = await env.ASSETS.fetch(request);
+      if (assetResponse.status !== 404) {
+        return assetResponse;
+      }
+      return env.ASSETS.fetch(new Request(new URL("/studio/index.html", request.url), request));
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,10 @@
 {
   "name": "fyrstikken",
+  "main": "./worker.ts",
   "compatibility_date": "2026-01-20",
   "assets": {
-    "directory": "./dist"
-  }
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "run_worker_first": ["/studio", "/studio/*"],
+  },
 }


### PR DESCRIPTION
## Summary

- Add a Cloudflare Worker (`worker.ts`) that intercepts `/studio/*` requests — serves real static assets directly, falls back to `/studio/index.html` for SPA client-side navigation
- Update `wrangler.jsonc` with `run_worker_first` to scope Worker execution to `/studio` routes only
- Fix asset path resolution in `copy-studio.js` — Sanity builds with root-relative paths (`/static/...`) which break when served from `/studio/`, now rewritten to `/studio/static/...`