### PR TITLE
Add hourly cron deploy schedule (7am–11pm UTC)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 7-23 * * *"
   workflow_dispatch:
   repository_dispatch:
     types: [sanity-content-update]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ const TS_JS_FILES = "**/*.{js,mjs,cjs,ts,tsx}";
 
 export default [
   {
-    ignores: ["dist", "node_modules", "**/.astro/**", ".netlify/**", "studio/**"],
+    ignores: ["dist", "node_modules", "**/.astro/**", ".netlify/**", ".sanity/**", "studio/**"],
   },
   eslint.configs.recommended,
   // Astro config MUST come before TypeScript configs


### PR DESCRIPTION
Adds a `schedule` trigger to the deploy workflow so it runs every hour from 07:00 to 23:00 UTC. This ensures the site is rebuilt and deployed regularly throughout the day, picking up any content changes from Sanity.